### PR TITLE
feat: add RPCs for session interactive action and fix type error in ConsoleCreateRes

### DIFF
--- a/consoles.go
+++ b/consoles.go
@@ -2,7 +2,7 @@ package msfrpc
 
 import "github.com/n3x7c04p/msfrpc/models"
 
-//consoles
+// consoles
 func (msf *Msfrpc) ConsoleCreate() (models.ConsoleCreateRes, error) {
 	req := &models.ConsoleCreateReq{Method: models.ConsoleCreate, Token: msf.token}
 	var res models.ConsoleCreateRes
@@ -21,9 +21,9 @@ func (msf *Msfrpc) ConsoleDestroy(ConsoleID string) (bool, error) {
 	return res.Result == "success", nil
 }
 
-func (msf *Msfrpc) ConsoleList() (map[int]models.ConsoleCreateRes, error) {
+func (msf *Msfrpc) ConsoleList() (map[string]models.ConsoleCreateRes, error) {
 	req := &models.ConsoleListReq{Method: models.ConsoleList, Token: msf.token}
-	res := make(map[int]models.ConsoleCreateRes)
+	res := make(map[string]models.ConsoleCreateRes)
 	if err := msf.send(req, &res); err != nil {
 		return nil, err
 	}

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
+github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/models/console.go
+++ b/models/console.go
@@ -7,7 +7,7 @@ type ConsoleCreateReq struct {
 }
 
 type ConsoleCreateRes struct {
-	ID     int    `msgpack:"id"`
+	ID     string `msgpack:"id"`
 	Prompt string `msgpack:"prompt"`
 	Busy   bool   `msgpack:"busy"`
 }

--- a/models/constant.go
+++ b/models/constant.go
@@ -95,6 +95,8 @@ const (
 	SessionRingPut                       = "session.ring_put"
 	SessionRingLast                      = "session.ring_last"
 	SessionRingClear                     = "session.ring_clear"
+	SessionInteractiveRead               = "session.interactive_read"
+	SessionInteractiveWrite              = "session.interactive_write"
 	SessionMeterpreterWrite              = "session.meterpreter_write"
 	SessionMeterpreterSessionDetach      = "session.meterpreter_session_detach"
 	SessionMeterpreterSessionKill        = "session.meterpreter_session_kill"

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -82,6 +82,29 @@ type SessionShellUpgradeRes struct {
 	Result string `msgpack:"result"`
 }
 
+type SessionInteractiveReadReq struct {
+	_msgpack  struct{} `msgpack:",asArray"`
+	Method    string
+	Token     string
+	SessionID string
+}
+
+type SessionInteractiveReadRes struct {
+	Data string `msgpack:"data"`
+}
+
+type SessionInteractiveWriteReq struct {
+	_msgpack  struct{} `msgpack:",asArray"`
+	Method    string
+	Token     string
+	SessionID string
+	Data      string
+}
+
+type SessionInteractiveWriteRes struct {
+	Result string `msgpack:"result"`
+}
+
 type SessionMeterpreterReadReq struct {
 	_msgpack  struct{} `msgpack:",asArray"`
 	Method    string

--- a/sessions.go
+++ b/sessions.go
@@ -2,7 +2,7 @@ package msfrpc
 
 import "github.com/n3x7c04p/msfrpc/models"
 
-//sessions
+// sessions
 func (msf *Msfrpc) SessionList() (map[int]models.SessionListRes, error) {
 	req := &models.SessionListReq{Method: models.SessionList, Token: msf.token}
 	res := make(map[int]models.SessionListRes)
@@ -62,6 +62,26 @@ func (msf *Msfrpc) SessionShellUpgrade(SessionID string, ConnHost string, ConnPo
 	return res.Result == "success", nil
 }
 
+func (msf *Msfrpc) SessionInteractiveRead(SessionID string) (string, error) {
+	req := &models.SessionInteractiveReadReq{Method: models.SessionInteractiveRead, Token: msf.token, SessionID: SessionID}
+	var res models.SessionInteractiveReadRes
+	if err := msf.send(req, &res); err != nil {
+		return "", err
+	}
+	return res.Data, nil
+}
+
+func (msf *Msfrpc) SessionInteractiveWrite(SessionID string, Data string) (bool, error) {
+	req := &models.SessionInteractiveWriteReq{Method: models.SessionInteractiveWrite, Token: msf.token, SessionID: SessionID, Data: Data}
+	var res models.SessionInteractiveWriteRes
+	if err := msf.send(req, &res); err != nil {
+		return false, err
+	}
+	return res.Result == "success", nil
+}
+
+// SessionMeterpreterRead
+// Deprecated. in favour of SessionInteractiveRead
 func (msf *Msfrpc) SessionMeterpreterRead(SessionID string) (string, error) {
 	req := &models.SessionMeterpreterReadReq{Method: models.SessionMeterpreterRead, Token: msf.token, SessionID: SessionID}
 	var res models.SessionMeterpreterReadRes
@@ -71,6 +91,8 @@ func (msf *Msfrpc) SessionMeterpreterRead(SessionID string) (string, error) {
 	return res.Data, nil
 }
 
+// SessionMeterpreterWrite
+// Deprecated. in favour of SessionInteractiveWrite
 func (msf *Msfrpc) SessionMeterpreterWrite(SessionID string, Data string) (bool, error) {
 	req := &models.SessionMeterpreterWriteReq{Method: models.SessionMeterpreterWrite, Token: msf.token, SessionID: SessionID, Data: Data}
 	var res models.SessionMeterpreterWriteRes


### PR DESCRIPTION
The library encountered a parsing problem with responses when interacting with metasploit 6.4.x. The current fix is ​​to change the field type, but this will introduce BREAKING CHANGE.

In addition, this PR submitted two new RPC interfaces and marked two RPC interfaces as Deprecated. The specific reasons come from this [document](https://docs.metasploit.com/api/Msf/RPC/RPC_Session.html#rpc_meterpreter_read-instance_method)
